### PR TITLE
Fixed pipeline page timeline and top 10 tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 			<!-- ++++++++++++++++++++++++++++++++++++++++++++++++ Row 1 +++++++++++++++++++++ -->
             <div class="pure-u-1 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r1b1" id="r1b1">
+                    <div class="container_box r1b1">
 	                    <!-- +++++++++++++++++++ Row 1, box 1 ++++++++++++++++++++++++++++++++
                         --><div class="box_header box_text pure-g-r">
                             Monthly spend
@@ -139,7 +139,7 @@
             ++++++++++++++++++++++++++++++++++++ Row 2 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             --><div class="pure-u-1 pure-u-lg-1-3 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r2b1" id="r2b1">
+                    <div class="container_box r2b1">
                       <!-- ++++++++++++++++++++++++++++++++++++ Row 2 box 1 ++++++++++++++++++++++++++++++++++++++++++++++++++ -->
                       <div class="box_header box_text pure-g-r">
                             Spend by category
@@ -179,7 +179,7 @@
 	        +++++++++ Row 2, box 2 ++++++++++++++++++++++++++++++++++++++++++
 	        --><div class="pure-u-1 pure-u-lg-1-3 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r2b2" id="r2b2"><!--
+                    <div class="container_box r2b2"><!--
                         --><div class="box_header box_text pure-g-r">
                             Supplier type
                         </div><!--
@@ -217,7 +217,7 @@
 	        ++++++++++++++++++++++ Row 2, box 3 ++++++++++++++++++++++++++++++++++++++++++
             --><div class="pure-u-1 pure-u-lg-1-3 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r2b3"  id="r2b3"><!--
+                    <div class="container_box r2b3"><!--
 						--><div class="box_header box_text pure-g-r">
                         Spend by service
                 </div><!--
@@ -302,7 +302,7 @@
 						<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++ end of row 3 ++++
 	        --><div class="pure-u-1 pure-u-lg-1-2 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r4b1"  id="r4b1">
+                    <div class="container_box r4b1">
                       <!-- ++++++++++++++++++++++++++++++ row 4, box 1 ++++++++++++++++++++++++++++++++++++++++++++-->
                         <div class="box_header box_text pure-g-r">
                             Top 10 small suppliers
@@ -332,7 +332,7 @@
             </div><!--
 	        --><div class="pure-u-1 pure-u-lg-1-2 dashboard-piece">
                 <div class="dashboard-content">
-                    <div class="container_box r4b2"  id="r4b2">
+                    <div class="container_box r4b2">
                       <!-- ++++++++++++++++++++++++++++++ row 4, box 2 ++++++++++++++++++++++++++++++++++++++++++++-->
                         <div class="box_header box_text pure-g-r">
                             Top 10 large suppliers

--- a/js/graphs.js
+++ b/js/graphs.js
@@ -513,36 +513,80 @@ function update_r4b1(year) {
 
     d3.json("https://dataclips.heroku.com/eylcztpirojwkpimoerwdantthcr-norfolk_supplier_top10_small.json", function (jsondata) {
 
-        var data = [];
+
+        var csv = [];
         for (var i = 0; i < jsondata['values'].length; i++) {
             var row = jsondata['values'][i];
-            data.push({
+            csv.push({
                 'supplier_name': row[0],
                 'sum': row[1],
                 'YYYY': row[2]
             });
         }
 
-        // console.log(data);
         if (typeof year !== "undefined") {
-            // console.log("filtering buildTopTenSupplierChart by ", year, '...');
-            data = dimple.filterData(data, 'YYYY', year);
-            // console.log("filtered data", data);
+            // console.log("filtering regionalSpendRing by ", year, '...');
+            data = dimple.filterData(csv, 'YYYY', year);
+
+            var data2 = d3.nest()
+                .key(function (d) {
+                    return d.supplier_name;
+                })
+                .rollup(function (d) {
+                    var arr = [];
+                    arr[0] = d3.sum(d, function (g) {
+                        return g.sum;
+                    });
+                    arr[1] = d[0].YYYY;
+                    return arr;
+                }).entries(data);
+
+
+        }
+        else {
+            var data2 = d3.nest()
+                .key(function (d) {
+                    return d.supplier_name;
+                })
+                .rollup(function (d) {
+                    var arr = [];
+                    arr[0] = d3.sum(d, function (g) {
+                        return g.sum;
+                    });
+                    arr[1] = d[0].YYYY;
+                    return arr;
+                }).entries(csv);
+
+
         }
 
-        ds = data.sort(function (a, b) {
-            return parseFloat(b.sum) - parseFloat(a.sum);
+
+        data2.sort(function (a, b) {
+            return parseFloat(a.values) - parseFloat(b.values)
+        });
+        data2.reverse();
+
+        var top10 = [];
+        var jj = 0;
+        var top2 = [];
+        data2.forEach(function (d) {
+            jj++;
+            if (jj <= 10) {
+                top10.push(new Object({ supplier_name: d.key, sum: d.values[0], YYYY: d.values[1]}));
+            }
+            if (top2.length < 2 && d.key != '(no data)') {
+                top2.push(new Object({supplier_name: d.key, sum: d.values[0]}));
+            }
         });
 
-        dt = ds.slice(0, 10);
-
-        var myChart = new dimple.chart(svg4_1, dt);
+        var myChart = new dimple.chart(svg4_1, top10);
         myChart.setBounds(4, 20, "88%", "80%");
         myChart.addMeasureAxis("x", "sum");
         var y = myChart.addCategoryAxis("y", "supplier_name");
         y.hidden = true;
+        y.addOrderRule("sum", false);
         // y.addOrderRule("supplier_name");
-        supplierChartSeries = myChart.addSeries(null, dimple.plot.bar);
+        var supplierChartSeries = myChart.addSeries(null, dimple.plot.bar);
         myChart.defaultColors = [
             new dimple.color("#81C936", "#81C936", 1), // Norfolk green
         ];
@@ -571,10 +615,10 @@ function update_r4b2(year) {
 
     d3.json("https://dataclips.heroku.com/xfgsnoumtajyxowzymyxhfuoaeza-norfolk_supplier_top10_medlarge.json", function (jsondata) {
 
-        var data = [];
+        var csv = [];
         for (var i = 0; i < jsondata['values'].length; i++) {
             var row = jsondata['values'][i];
-            data.push({
+            csv.push({
                 'supplier_name': row[0],
                 'sum': row[1],
                 'YYYY': row[2]
@@ -582,17 +626,61 @@ function update_r4b2(year) {
         }
 
         if (typeof year !== "undefined") {
-            // console.log("filtering buildTopTenBuyerChart by ", year, '...');
-            data = dimple.filterData(data, 'YYYY', year);
+            // console.log("filtering regionalSpendRing by ", year, '...');
+            data = dimple.filterData(csv, 'YYYY', year);
+
+            var data2 = d3.nest()
+                .key(function (d) {
+                    return d.supplier_name;
+                })
+                .rollup(function (d) {
+                    var arr = [];
+                    arr[0] = d3.sum(d, function (g) {
+                        return g.sum;
+                    });
+                    arr[1] = d[0].YYYY;
+                    return arr;
+                }).entries(data);
+
+
+        }
+        else {
+            var data2 = d3.nest()
+                .key(function (d) {
+                    return d.supplier_name;
+                })
+                .rollup(function (d) {
+                    var arr = [];
+                    arr[0] = d3.sum(d, function (g) {
+                        return g.sum;
+                    });
+                    arr[1] = d[0].YYYY;
+                    return arr;
+                }).entries(csv);
+
+
         }
 
-        ds = data.sort(function (a, b) {
-            return parseFloat(b.sum) - parseFloat(a.sum);
+
+        data2.sort(function (a, b) {
+            return parseFloat(a.values) - parseFloat(b.values)
+        });
+        data2.reverse();
+
+        var top10 = [];
+        var jj = 0;
+        var top2 = [];
+        data2.forEach(function (d) {
+            jj++;
+            if (jj <= 10) {
+                top10.push(new Object({ supplier_name: d.key, sum: d.values[0], YYYY: d.values[1]}));
+            }
+            if (top2.length < 2 && d.key != '(no data)') {
+                top2.push(new Object({supplier_name: d.key, sum: d.values[0]}));
+            }
         });
 
-        dt = ds.slice(0, 10);
-
-        var myChart = new dimple.chart(svg4_2, dt);
+        var myChart = new dimple.chart(svg4_2, top10);
         myChart.setBounds(4, 20, "88%", "80%");
         myChart.addMeasureAxis("x", "sum");
         var y = myChart.addCategoryAxis("y", "supplier_name");

--- a/js/main.js
+++ b/js/main.js
@@ -51,7 +51,7 @@ $(document).ready(function() {
       console.debug("converting ", year, ":");
       switch (parseInt(year)) {
         case 2011:
-          // console.debug("214");
+           //console.debug("214");
           return "FY 2011/12";
         case 2012:
           return "FY 2012/13";

--- a/js/norfolk_pipeline_page.js
+++ b/js/norfolk_pipeline_page.js
@@ -32,14 +32,13 @@ $(document).ready(function() {
         }
 
         var lowest_date = Math.min.apply(Math,dYears).toString();
-        var lowest_date_formatted = lowest_date.substring(0,4)+'-'+lowest_date.substr(4,2)+'-'+lowest_date.substr(6,2);
+        var lowest_date_formatted = lowest_date.substring(0,4)+'-'+lowest_date.substr(4,2)+'-01';
         var highest_year = parseInt(lowest_date.substring(0,4))+5;
         var highest_date_formatted = highest_year+'-'+lowest_date.substr(4,2)+'-'+lowest_date.substr(6,2);
 
         var date_selection_end_year = parseInt(lowest_date.substring(0,4))+1;
         var date_selection_start_formatted = lowest_date_formatted;
-        var date_selection_end_formatted = date_selection_end_year+'-'+lowest_date.substr(4,2)+'-'+lowest_date.substr(6,2);
-
+        var date_selection_end_formatted = date_selection_end_year+'-'+lowest_date.substr(4,2)+'-01';
 
         // store json results for later reference
         NFPipeline.payload = payload;


### PR DESCRIPTION
- Fixed top 10 suppliers small/large tables showing only 6 rows instead of 10. Changed to descending ordering.
- Fixed pipeline page start date to always begin at xxxx-xx-01 instead of lowest day with a value. So timeline matches contract end date.
